### PR TITLE
WORK IN PROGRESS: Make SCHEMA required for all conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The 0xcert Framework is a mono repository with all framework related packages st
 
 ## Development
 
-We use [RushJS](https://rushjs.io) to manage this repository. Some quick notes on how to manage the repository are documented [here](https://gist.github.com/xpepermint/eecfc6ad6cd7c9f5dcda381aa255738d). But here is a quick start to run the test suite if you have just cloned this repository and never used RushJS before. Expect to spend 10 minutes building and running this test suite for the first time. Subsequently testing any code will take approximately 3 minutes and the full test suite must be run (even during development) for any change in any package.
+We use [RushJS](https://rushjs.io) to manage this repository. Some quick notes on how to manage the repository are documented [here](https://gist.github.com/xpepermint/eecfc6ad6cd7c9f5dcda381aa255738d). But here is a quick start to run the test suite if you have just cloned this repository and never used RushJS before. Expect to spend 10 minutes building and running this test suite for the first time. Subsequently testing any code will be faster, and you can limit testing to a specific package.
 
 **Install dependencies** -- You only need to run this once.
 
@@ -23,6 +23,13 @@ rush update --full
 ```sh
 rush rebuild --verbose
 rush test --verbose
+```
+
+**Shortcut** -- Do this if only want to change and retest one package
+
+```sh
+rush rebuild -t @0xcert/conventions  # Where CONVENTIONS is the package you want
+rush test -v -t @0xcert/conventions  # Where CONVENTIONS is the package you want
 ```
 
 The above notes will help you decide which commands to run during development on your own machine. But for any commits and pull requests in this repository, the entire test suite will be run using continuous integration.

--- a/conventions/86-base-asset-schema.md
+++ b/conventions/86-base-asset-schema.md
@@ -39,7 +39,7 @@ This schema extends [ERC721 Metadata JSON Schema](https://eips.ethereum.org/EIPS
   "description": "An abstract digital asset schema.",
   "properties": {
     "$evidence": {
-      "description": "A URI ponit to the evidence JSON with data needed to certify this asset.",
+      "description": "A URI pointing to the evidence JSON with data needed to certify this asset.",
       "type": "string",
     },
     "$schema": {

--- a/conventions/87-asset-evidence-schema.md
+++ b/conventions/87-asset-evidence-schema.md
@@ -78,7 +78,8 @@ The 0xcert framework provides an algorithm for creates proofs from asset data ob
       "type": "array"
     }
   },
-  "type": "object"
+  "type": "object",
+  "required": ["$schema"]
 }
 ```
 
@@ -86,7 +87,7 @@ The 0xcert framework provides an algorithm for creates proofs from asset data ob
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "https://raw.githubusercontent.com/0xcert/framework/master/conventions/86-base-asset-schema.md",
   "data": [
     {
       "path": [],

--- a/conventions/88-crypto-collectible-schema.md
+++ b/conventions/88-crypto-collectible-schema.md
@@ -27,7 +27,8 @@ This convention represents a digital asset that represents a crypto-collectible.
   ],
   "description": "A digital assets that have a unique combination of different properties.",
   "title": "Crypto Collectible Asset",
-  "type": "object"
+  "type": "object",
+  "required": ["$schema"]
 }
 ```
 
@@ -36,7 +37,7 @@ This convention represents a digital asset that represents a crypto-collectible.
 ```json
 {
   "$evidence": "https://troopersgame.com/dog/evidence",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "https://raw.githubusercontent.com/0xcert/framework/master/conventions/86-base-asset-schema.md",
   "description": "A weapon for the Troopers game which can severely injure the enemy.",
   "image": "https://troopersgame.com/dog.jpg",
   "name": "Magic Sword"

--- a/packages/0xcert-conventions/src/assets/86-base-asset.ts
+++ b/packages/0xcert-conventions/src/assets/86-base-asset.ts
@@ -5,7 +5,7 @@ import { ObjectErc721, schemaErc721 } from './erc721';
  */
 export interface Object86 extends ObjectErc721 {
   $evidence?: string;
-  $schema?: string;
+  $schema: string;
   description?: string;
   image?: string;
   name?: string;
@@ -30,4 +30,5 @@ export const schema86 = {
   },
   title: 'Base Asset',
   type: 'object',
+  required: ['$schema'],
 };

--- a/packages/0xcert-conventions/src/assets/87-asset-evidence.ts
+++ b/packages/0xcert-conventions/src/assets/87-asset-evidence.ts
@@ -2,7 +2,7 @@
  * Asset evidence object interface.
  */
 export interface Object87 {
-  $schema?: string;
+  $schema: string;
   data: {
     nodes: {
       index: number;
@@ -80,4 +80,5 @@ export const schema87 = {
   },
   title: 'Asset evidence',
   type: 'object',
+  required: ['$schema'],
 };

--- a/packages/0xcert-conventions/src/assets/88-crypto-collectible.ts
+++ b/packages/0xcert-conventions/src/assets/88-crypto-collectible.ts
@@ -5,7 +5,7 @@ import { Object86, schema86 } from './86-base-asset';
  */
 export interface Object88 extends Object86 {
   $evidence?: string;
-  $schema?: string;
+  $schema: string;
   description: string;
   image: string;
   name: string;
@@ -22,4 +22,5 @@ export const schema88 = {
   },
   title: 'Crypto Collectible',
   type: 'object',
+  required: ['$schema'],
 };

--- a/packages/0xcert-conventions/src/tests/86-base-asset.test.ts
+++ b/packages/0xcert-conventions/src/tests/86-base-asset.test.ts
@@ -23,6 +23,13 @@ spec.test('Validates data', (ctx) => {
     'name': 12,
   };
   ctx.false(validate(data2));
+  const data3 = {
+    '$evidence': 'https://troopersgame.com/dog/evidence',
+    'description': 'A weapon for the Troopers game which can severely injure the enemy.',
+    'image': 'https://troopersgame.com/dog.jpg',
+    'name': 'Troopers game',
+  };
+  ctx.false(validate(data3));
 });
 
 export default spec;


### PR DESCRIPTION
This updates all conventions to make `$schema` a required property. This is a necessary part of the 0xcert protocol because introspection is used to verify the imprint. (Explicitly setting the schema is also supported.)

Blockers:

- [ ] Publish all machine-readable convention JSON schemas to a publicly-accessible location.
- [ ] Update the `$schema` properties here to point to those URIs.

When blockers are resolved then this is ready to merge.