### PR TITLE
Simplify ethereum-utils package

### DIFF
--- a/packages/0xcert-ethereum-utils/README.md
+++ b/packages/0xcert-ethereum-utils/README.md
@@ -5,3 +5,70 @@
 The [0xcert Framework](https://docs.0xcert.org) is a free and open-source JavaScript library that provides tools for building powerful decentralized applications. Please refer to the [official documentation](https://docs.0xcert.org) for more details.
 
 This module is one of the bricks of the [0xcert Framework](https://docs.0xcert.org). It's written with [TypeScript](https://www.typescriptlang.org) and it's actively maintained. The source code is available on [GitHub](https://github.com/0xcert/framework) where you can also find our [issue tracker](https://github.com/0xcert/framework/issues).
+
+# Ethereum Utilities
+
+This module wraps several useful Ethereum functions which will be useful through the 0xcert Framework. Currently supported are these functions and classes from [ethers.js](https://github.com/ethers-io/ethers.js):
+
+## ABI coder
+
+This converts value to and from the packed [Ethereum ABI encoding](https://solidity.readthedocs.io/en/develop/abi-spec.html#formal-specification-of-the-encoding).
+
+* `encodeParameters`(types: `any`, values: `Array<any>`): `string`
+* `decodeParameters`(types: `any`, data: `any`): `any`
+
+**Encoding example:**
+
+```ts
+import { decodeParameters, encodeParameters } from '0xcert/ethereum-utils/abi';
+
+const types = ['tuple(uint256, uint256[])'];
+const values = [[ 42, [ 45 ] ]];
+const encodedValues = encodeParameters(types, values);
+```
+
+**Decoding example:**
+
+```ts
+import { decodeParameters, encodeParameters } from '0xcert/ethereum-utils/abi';
+
+const types = ['tuple(uint256, uint256[])'];
+const encoded = '0x' +
+  '0000000000000000000000000000000000000000000000000000000000000020' +
+  '000000000000000000000000000000000000000000000000000000000000002a' +
+  '0000000000000000000000000000000000000000000000000000000000000040' +
+  '0000000000000000000000000000000000000000000000000000000000000001' +
+  '000000000000000000000000000000000000000000000000000000000000002d';
+const values = decodeParameters(types, values);
+```
+
+## BigNumber and bigNumberify
+
+Here is a basic example adapted from [the ethers.js documentation](https://docs.ethers.io/ethers.js/html/api-utils.html?highlight=bignumberify#big-numbers).
+
+```ts
+import { BigNumber, bigNumberify } from '0xcert/ethereum-utils/big-number';
+
+let gasPriceWei = bigNumberify("20902747399");
+let gasLimit = bigNumberify(3000000);
+
+let maxCostWei = gasPriceWei.mul(gasLimit)
+console.log("Max Cost: " + maxCostWei.toString());
+// "Max Cost: 62708242197000000"
+
+console.log("Number: " + maxCostWei.toNumber());
+// throws an Error, the value is too large for JavaScript to handle safely
+```
+
+## Address normalization
+
+The ethers.js [address normalization function](https://docs.ethers.io/ethers.js/html/api-utils.html?highlight=getaddress#addresses) implements [EIP-55 Mixed-case checksum address encoding](https://eips.ethereum.org/EIPS/eip-55).
+
+
+```ts
+import { getAddress } from '0xcert/ethereum-utils/normalize-address';
+
+let zxcTokenAddress = '0x83e2be8d114f9661221384b3a50d24b96a5653f5';
+let zxcTokenAddressNormalized = normalizeAddress(zxcToenAddress);
+// 0x83e2BE8d114F9661221384B3a50d24B96a5653F5
+```

--- a/packages/0xcert-ethereum-utils/package.json
+++ b/packages/0xcert-ethereum-utils/package.json
@@ -8,17 +8,14 @@
     "build": "npm run clean && npx tsc",
     "clean": "rm -Rf ./dist",
     "lint": "npx tslint 'src/**/*.ts?(x)'",
-    "test": "npx nyc npx specron test"
+    "test": "npm run lint && npx nyc npx hayspec test"
   },
-  "specron": {
-    "test": {
-      "port": 8523,
-      "match": [
-        "./src/tests/**/*.test.ts"
-      ]
-    },
+  "hayspec": {
     "require": [
       "ts-node/register"
+    ],
+    "match": [
+      "./src/tests/**/*.test.ts"
     ]
   },
   "nyc": {
@@ -67,16 +64,11 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@0xcert/ethereum-sandbox": "1.0.0-rc2",
-    "@specron/cli": "^0.5.2",
-    "@specron/spec": "^0.5.2",
-    "nyc": "^13.1.0",
-    "solc": "0.5.1",
+    "@hayspec/cli": "^0.8.3",
+    "@hayspec/spec": "^0.8.3",
     "ts-node": "^7.0.1",
     "tslint": "^5.12.1",
-    "typescript": "^3.1.1",
-    "web3": "1.0.0-beta.36",
-    "@0xcert/utils": "1.0.0-rc2"
+    "typescript": "^3.1.1"
   },
   "dependencies": {
     "ethers": "4.0.0-beta.1"

--- a/packages/0xcert-ethereum-utils/src/lib/abi.ts
+++ b/packages/0xcert-ethereum-utils/src/lib/abi.ts
@@ -2,10 +2,10 @@ import { AbiCoder } from 'ethers/utils/abi-coder';
 
 const coder = new AbiCoder();
 
-export function encodeParameters(types: any, values: any) {
+export function encodeParameters(types: any, values: Array<any>): string {
   return coder.encode(types, values);
 }
 
-export function decodeParameters(types: any, data: any) {
+export function decodeParameters(types: any, data: any): any {
   return coder.decode(types, data);
 }

--- a/packages/0xcert-ethereum-utils/src/lib/normalize-address.ts
+++ b/packages/0xcert-ethereum-utils/src/lib/normalize-address.ts
@@ -4,6 +4,6 @@ import { getAddress } from 'ethers/utils/address';
  * Converts ethereum address to checksum format.
  * @see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
  */
-export function normalizeAddress(address: string) {
+export function normalizeAddress(address: string): string {
   return getAddress(address);
 }

--- a/packages/0xcert-ethereum-utils/src/tests/encode-parameters.test.ts
+++ b/packages/0xcert-ethereum-utils/src/tests/encode-parameters.test.ts
@@ -1,12 +1,60 @@
-import { Spec } from '@specron/spec';
-import { encodeParameters } from '../lib/abi';
+import { Spec } from '@hayspec/spec';
+import { decodeParameters, encodeParameters } from '../lib/abi';
+import { bigNumberify } from '../lib/big-number';
 
 const spec = new Spec();
 
 spec.test('encode parameters', (ctx) => {
+  const types = ['tuple(uint256, uint256[])'];
+  const values = [[ 42, [ 45 ] ]];
+  const encoded = '0x' +
+  '0000000000000000000000000000000000000000000000000000000000000020' +
+  '000000000000000000000000000000000000000000000000000000000000002a' +
+  '0000000000000000000000000000000000000000000000000000000000000040' +
+  '0000000000000000000000000000000000000000000000000000000000000001' +
+  '000000000000000000000000000000000000000000000000000000000000002d';
+
   ctx.is(
-    encodeParameters(['tuple(uint256, uint256[])'], [[ 42, [ 45 ] ]]),
-    '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002d',
+    encodeParameters(types, values),
+    encoded,
+  );
+
+  // Testing function which compares values, even nested in a BigNumber
+  // Source: https://github.com/ethers-io/ethers.js/blob/typescript/tests/test-contract-interface.js
+  function equals(actual, expected) {
+
+    // Array (treat recursively)
+    if (Array.isArray(actual)) {
+      if (!Array.isArray(expected) || actual.length !== expected.length) { return false; }
+      for (let i = 0; i < actual.length; i++) {
+        if (!equals(actual[i], expected[i])) { return false; }
+      }
+      return true;
+    }
+
+    if (typeof(actual) === 'number') { actual = bigNumberify(actual); }
+    if (typeof(expected) === 'number') { expected = bigNumberify(expected); }
+
+    // BigNumber
+    if (actual.eq) {
+      if (typeof(expected) === 'string' && expected.match(/^-?0x[0-9A-Fa-f]*$/)) {
+        const neg = (expected.substring(0, 1) === '-');
+        if (neg) { expected = expected.substring(1); }
+        expected = bigNumberify(expected);
+        if (neg) { expected = expected.mul(-1); }
+      }
+      if (!actual.eq(expected)) { return false; }
+      return true;
+    }
+
+    // Something else
+    return (actual === expected);
+  }
+
+  const result = decodeParameters(types, encoded);
+  ctx.is(
+    equals(result, values),
+    true,
   );
 });
 

--- a/packages/0xcert-ethereum-utils/src/tests/normalize-address.test.ts
+++ b/packages/0xcert-ethereum-utils/src/tests/normalize-address.test.ts
@@ -1,4 +1,4 @@
-import { Spec } from '@specron/spec';
+import { Spec } from '@hayspec/spec';
 import { normalizeAddress } from '../lib/normalize-address';
 
 const spec = new Spec();


### PR DESCRIPTION
* Removes dependencies which were not needed
  * Speeds up `rush` build time by allowing more parallelization
* Removes Specron dependency, switches to Haystack
  * Specron was required for smart contract validation but ethereum-utils did not have smart contracts
* Increased to 100% test coverage
  * Testing one of the functions was non-trivial, so code was imported (compatible license) from ethers.js to do the test comparison
* Improved test suite coverage
  * Previously linting was not included in the test, now it is
* Fixed lint failure
  * The previous test suite's lack of a linting feature allowed a lint error to go unnoticed, now that error is fixed