### PR TITLE
Update communication.md

### DIFF
--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -22,7 +22,7 @@ const ledgerId = '0xcc567f78e8821fb8d19f7e6240f44553ce3dbfce';
 const ledger = new AssetLedger(provider, ledgerId);
 
 // perform a query
-const balance = await ledger.getBalance(accountId);
+const balance = await ledger.getBalance(ledgerId);
 ```
 
 ## What are mutations?


### PR DESCRIPTION
Change accountId to ledgerId in first example, last line - could be useful to explain in comments that ledgerId is, in the case of ethereum, an ethereum address.
Edit: from inspecting the API, I misunderstood the example as ledgerId is an NFT address. Please ignore this pull request.