### PR TITLE
Add eth_sendRawTransaction method to use the privateKey of the user account

### DIFF
--- a/packages/0xcert-ethereum-generic-provider/package.json
+++ b/packages/0xcert-ethereum-generic-provider/package.json
@@ -82,6 +82,7 @@
   "dependencies": {
     "@0xcert/ethereum-utils": "1.8.0",
     "@0xcert/scaffold": "1.8.0",
-    "events": "^3.0.0"
+    "events": "^3.0.0",
+    "ethers": "4.0.0-beta.1"
   }
 }

--- a/packages/0xcert-ethereum-generic-provider/src/core/types.ts
+++ b/packages/0xcert-ethereum-generic-provider/src/core/types.ts
@@ -6,6 +6,7 @@ export enum SignMethod {
   TREZOR = 1,
   EIP712 = 2,
   PERSONAL_SIGN = 3,
+  RAW_TX_SIGN = 4,
 }
 
 /**

--- a/packages/0xcert-ethereum-http-provider/src/core/provider.ts
+++ b/packages/0xcert-ethereum-http-provider/src/core/provider.ts
@@ -12,6 +12,11 @@ export interface HttpProviderOptions {
   accountId?: string;
 
   /**
+   * Default privateKey from which all mutations are made.
+   */
+  privateKey?: string;
+
+  /**
    * Http call cache options.
    */
   cache?: 'default' | 'no-cache' | 'reload' | 'force-cache' | 'only-if-cached' | string;


### PR DESCRIPTION
This is my implementation to use the ethereum method `eth_sendRawTransactions` to sign transactions using the privateKey of the user account. It works for our needs and I know it's not the best solution but the idea can help you and others to implement this new feature.

Regards!.